### PR TITLE
Hotfix/scroll top not working

### DIFF
--- a/ui/components/responsive-table/index.twig
+++ b/ui/components/responsive-table/index.twig
@@ -22,7 +22,7 @@
     ]
 ] %}
 
-{% include 'components/responsiveTable/responsive-table.twig' with {
+{% include 'components/responsive-table/responsive-table.twig' with {
     component: {
         heading: heading,
         body: body,

--- a/ui/components/scroll-top/index.twig
+++ b/ui/components/scroll-top/index.twig
@@ -2,4 +2,4 @@
 <div style="margin-top: 800px;"></div>
 <p>Bottom</p>
 
-{% include 'components/scrollTop/scroll-top.twig' %}
+{% include 'components/scroll-top/scroll-top.twig' %}


### PR DESCRIPTION
Components Scroll Top and Responsive Table were not loading because of a twig include mispelling.